### PR TITLE
Link instruction and get-started pages

### DIFF
--- a/docs/get-started/index.rst
+++ b/docs/get-started/index.rst
@@ -9,3 +9,5 @@ The Ubuntu for Jetson images are intended for Jetson Orin or Thor developer kits
 
 * as a LTS alternative to Jetpack
 * to run AI workflows
+
+:doc:`/how-to/flash`

--- a/docs/how-to/flash.rst
+++ b/docs/how-to/flash.rst
@@ -246,3 +246,7 @@ At every boot, you will get a chance to enter the UEFI menu by pressing Escape o
     ..
 
 This menu will eventually allow you to select a different boot option. If you don’t press a key, UEFI will automatically launch the default option.
+
+NVIDIA runtime
+--------------
+:doc:`/classic/installation`


### PR DESCRIPTION
I think we miss a link in between the 2 instruction pages. The RTD pages are definitely better than the previous PDF exports, but one could get lost trying to find his way (not for long, ok, but...)