### PR TITLE
new: Include a sub-section about building a server image

### DIFF
--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -18,7 +18,7 @@ Prerequisites
 Create an image definition file
 -------------------------------
 
-To build a custom Ubuntu Server image, there is needed an image definition YAML file, which specifies required configurations, like the ones listed below.
+An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
 
 * **class**: Type of image cloud, installer, or preinstalled.
 * **kernel**: By default there is just one kernel and defaults to "linux", but through this field there can be specified an alternative kernel to install in the image.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -37,7 +37,7 @@ The `ubuntu-images`_ repository serves as the official source for Canonical’s 
 Ubuntu certified Image definition files
 ---------------------------------------
 
-Provided below are the image definition files utilized in the generation of Ubuntu Server images certified by Canonical.
+The following command allows to check the definition files used to generate the Ubuntu Server image certified by Canonical:
 
 .. _Certified Ubuntu Server Jammy image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=jammy
 .. _Certified Ubuntu Server Noble image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=noble

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -21,7 +21,7 @@ Create an image definition file
 An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
 
 * **class**: Type of image: cloud, installer or preinstalled.
-* **kernel**: By default there is just one kernel and defaults to "linux", but through this field there can be specified an alternative kernel to install in the image.
+* **kernel**: This field specifies the kernel for installation in the image. While "linux-nvidia-tegra-jetson" is the standard publicly available version for Tegra platforms, it can be replaced with an alternative kernel, such as one from a PPA, if required.
 * **gadget**: Boot assets of an image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.
 * **artifacts**: Artifacts to create, including (but not limited to) the actual images, and manifest files.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -1,0 +1,46 @@
+.. _build-image:
+
+Create a custom Ubuntu Server image
+===================================
+
+
+Prerequisites
+-------------
+
+* `Ubuntu-image`_ must be installed on a build environment running Ubuntu 20.04 (Focal Fossa) or newer. It is recommended to use Ubuntu 24.04 (Noble Numbat).
+
+.. _Ubuntu-image: https://github.com/canonical/ubuntu-image
+
+.. code-block:: bash
+
+    sudo snap install --classic --channel latest/stable ubuntu-image
+
+Create an image definition file
+-------------------------------
+
+To build a custom Ubuntu Server image, there is needed an image definition YAML file, which specifies required configurations, like the ones listed below.
+
+* **class**: Type of image cloud, installer, or preinstalled.
+* **kernel**: By default there is just one kernel and defaults to "linux", but through this field there can be specified an alternative kernel to install in the image.
+* **gadget**: Boot assets of an image.
+* **customization**: Features such as particular snaps and packages that will come installed in the image.
+* **artifacts**: Artifacts to create, including (but not limited to) the actual images, and manifest files.
+
+For more details about each field the `image definition`_ documentation can be consulted.
+
+.. _image definition: https://github.com/canonical/ubuntu-image/blob/main/internal/imagedefinition/README.rst
+
+This is an `example of the image definition`_ file used to build the preinstalled images for Jetson devices.
+
+.. _example of the image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=jammy
+
+Build the Classic Server image
+------------------------------
+
+Once having the corresponding image definition file, the server image can be built through the following command.
+
+.. code-block:: bash
+
+    sudo ubuntu-image classic <image_definition>.yaml --debug
+
+On the example above, the `--debug`  flag prints additional information about each step executed as part of the image build process, useful to troubleshoot any issues while running the command.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -20,7 +20,7 @@ Create an image definition file
 
 An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
 
-* **class**: Type of image cloud, installer, or preinstalled.
+* **class**: Type of image: cloud, installer or preinstalled.
 * **kernel**: By default there is just one kernel and defaults to "linux", but through this field there can be specified an alternative kernel to install in the image.
 * **gadget**: Boot assets of an image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -34,157 +34,23 @@ The `ubuntu-images`_ repository serves as the official source for Canonical’s 
 
 .. _ubuntu-images: https://git.launchpad.net/ubuntu-images
 
+Ubuntu certified Image definition files
+---------------------------------------
+
+Provided below are the image definition files utilized in the generation of Ubuntu Server images certified by Canonical.
+
+.. _Certified Ubuntu Server Jammy image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=jammy
+.. _Certified Ubuntu Server Noble image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=noble
+
 .. tabs::
 
    .. group-tab:: Jammy
 
-      .. code-block:: bash
-
-            name: ubuntu-server-tegra-jetson-arm64
-            display-name: Ubuntu Server Tegra Jetson arm64
-            revision: 2
-            architecture: arm64
-            series: jammy
-            class: preinstalled
-            kernel: linux-nvidia-tegra-jetson
-            gadget:
-              url: "https://git.launchpad.net/~canonical-foundations/snap-pc/+git/github-mirror-amd64"
-              branch: classic
-              type: "git"
-            rootfs:
-              mirror: "http://ports.ubuntu.com/ubuntu-ports/"
-              pocket: updates
-              components:
-                - main
-                - restricted
-                # TODO should ideally not enable universe during image build; kernel is now
-                # in main, but need to MIR nvidia-tegra-defaults and list it in a seed (see
-                # LP #2083775 for a proposal to add seeds)
-                - universe
-                - multiverse
-              seed:
-                urls:
-                  - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-                branch: jammy
-                names:
-                  - server
-                  - minimal
-                  - standard
-                  - cloud-image
-                  # TODO would like to list server-tegra here once available (see
-                  # LP #2083775)
-            customization:
-              # We need to duplicate the list of components as we currently have some
-              # packages in universe and multiverse
-              components:
-                - main
-                - restricted
-                - universe
-                - multiverse
-              cloud-init:
-                user-data: |
-                  #cloud-config
-                  chpasswd:
-                    expire: true
-                    users:
-                      - name: ubuntu
-                        password: ubuntu
-                        type: text
-                meta-data: |
-                  dsmode: local
-                  instance_id: ubuntu-server
-              extra-snaps:
-                - name: snapd
-                # FIXME ubuntu-image fails in prepare_image if this isn't listed: cannot
-                # add snap "lxd" without also adding its base "core20" explicitly
-                - name: core20
-              extra-packages:
-                # FIXME using extra-packages as a workaround for missing bits to make the
-                # system bootable and has the right platform specific packages installed;
-                # this could be pulled by seeds or metapackages while we design a more
-                # scalable solution (see LP #2083775)
-                # signed EFI boot chain
-                - name: grub-efi-arm64-signed
-                - name: shim-signed
-                # add serial consoles to cmdline via GRUB config
-                - name: nvidia-tegra-defaults
-                # to get wireless support with netplan.io
-                - name: wpasupplicant
-                # install Tegra Orin firmware files
-                - name: linux-firmware-nvidia-tegra
-            artifacts:
-              img:
-                -
-                  name: ubuntu-22.04-preinstalled-server-arm64+tegra-jetson.img
-              manifest:
-                name: ubuntu-22.04-preinstalled-server-arm64+tegra-jetson.manifest
+      `Certified Ubuntu Server Jammy image definition`_
 
    .. group-tab:: Noble
 
-      .. code-block:: bash
-
-            name: ubuntu-server-jetson-arm64
-            display-name: Ubuntu Server Jetson arm64
-            revision: 1
-            architecture: arm64
-            series: noble
-            class: preinstalled
-            kernel: linux-nvidia-tegra-jetson
-            gadget:
-              url: "https://git.launchpad.net/~canonical-foundations/snap-pc/+git/github-mirror-amd64"
-              branch: "classic"
-              type: "git"
-            rootfs:
-              archive: ubuntu
-              components:
-                - main
-                - restricted
-                - universe
-                - multiverse
-              mirror: "http://ports.ubuntu.com/ubuntu-ports/"
-              sources-list-deb822: true
-              pocket: updates
-              seed:
-                urls:
-                  - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-                branch: noble
-                names:
-                  - server
-                  - minimal
-                  - standard
-                  - cloud-image
-            customization:
-              extra-snaps:
-                - name: snapd
-              extra-packages:
-                # FIXME using extra-packages as a workaround for missing bits to make the
-                # system bootable that should be pulled by seeds or metapackages
-                # signed EFI boot chain
-                - name: grub-efi-arm64-signed
-                - name: shim-signed
-                # for update-grub
-                - name: grub2-common
-                - name: nvidia-tegra-defaults
-                - name: wpasupplicant
-                # install Tegra firmware files
-                - name: linux-firmware-nvidia-tegra
-              cloud-init:
-                user-data: |
-                  #cloud-config
-                  chpasswd:
-                    expire: true
-                    users:
-                      - name: ubuntu
-                        password: ubuntu
-                        type: text
-                meta-data: |
-                  dsmode: local
-                  instance_id: ubuntu-server
-            artifacts:
-              img:
-                - name: ubuntu-24.04-preinstalled-server-arm64+jetson.img
-              manifest:
-                name: ubuntu-24.04-preinstalled-server-arm64+jetson.manifest
+      `Certified Ubuntu Server Noble image definition`_
 
 Build the Classic Server image
 ------------------------------

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -7,7 +7,7 @@ Create a custom Ubuntu Server image
 Prerequisites
 -------------
 
-* `Ubuntu-image`_ must be installed on a build environment running Ubuntu 20.04 (Focal Fossa) or newer. It is recommended to use Ubuntu 24.04 (Noble Numbat).
+* `Ubuntu-image`_ is the tool used by Canonical to build official Ubuntu images. It must be installed on a build environment running Ubuntu 20.04 (Focal Fossa) or newer. It is recommended to use Ubuntu 24.04 (Noble Numbat).
 
 .. _Ubuntu-image: https://github.com/canonical/ubuntu-image
 

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -26,7 +26,7 @@ An image definition YAML file is required to build a custom Ubuntu Server image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.
 * **artifacts**: Artifacts to create, including (but not limited to) the actual images, and manifest files.
 
-For more details about each field, the `image definition`_ documentation can be consulted.
+For more details about each field, refer to the `image definition`_ documentation.
 
 .. _image definition: https://github.com/canonical/ubuntu-image/blob/main/internal/imagedefinition/README.rst
 

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -20,7 +20,7 @@ Create an image definition file
 
 An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
 
-* **class**: Type of image: cloud, installer or preinstalled.
+* **class**: Defines the type of image, such as `cloud`, `installer` or `preinstalled` (Canonical's certified Server images are preinstalled).
 * **kernel**: This field specifies the kernel for installation in the image. While "linux-nvidia-tegra-jetson" is the standard publicly available version for Tegra platforms, it can be replaced with an alternative kernel, such as one from a PPA, if required.
 * **gadget**: Boot assets of an image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -55,7 +55,7 @@ The following command allows to check the definition files used to generate the 
 Build the Classic Server image
 ------------------------------
 
-Once having the corresponding image definition file, the server image can be built through the following command.
+Once the corresponding image definition file is defined, the server image can be built through the following command.
 
 .. code-block:: bash
 

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -21,7 +21,7 @@ Create an image definition file
 An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
 
 * **class**: Defines the type of image, such as `cloud`, `installer` or `preinstalled` (Canonical's certified Server images are preinstalled).
-* **kernel**: This field specifies the kernel for installation in the image. While "linux-nvidia-tegra-jetson" is the standard publicly available version for Tegra platforms, it can be replaced with an alternative kernel, such as one from a PPA, if required.
+* **kernel**: Specifies the preinstalled kernel in the image. The official Ubuntu kernel for Jetson is "linux-nvidia-tegra-jetson", but it can be replaced with an alternative custom kernel, for instance hosted in a PPA for development purpose.
 * **gadget**: Boot assets of an image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.
 * **artifacts**: Artifacts to create, including (but not limited to) the actual images, and manifest files.

--- a/docs/how-to/build-image.rst
+++ b/docs/how-to/build-image.rst
@@ -26,13 +26,165 @@ An image definition YAML file is required to build a custom Ubuntu Server image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.
 * **artifacts**: Artifacts to create, including (but not limited to) the actual images, and manifest files.
 
-For more details about each field the `image definition`_ documentation can be consulted.
+For more details about each field, the `image definition`_ documentation can be consulted.
 
 .. _image definition: https://github.com/canonical/ubuntu-image/blob/main/internal/imagedefinition/README.rst
 
-This is an `example of the image definition`_ file used to build the preinstalled images for Jetson devices.
+The `ubuntu-images`_ repository serves as the official source for Canonical’s image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
 
-.. _example of the image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=jammy
+.. _ubuntu-images: https://git.launchpad.net/ubuntu-images
+
+.. tabs::
+
+   .. group-tab:: Jammy
+
+      .. code-block:: bash
+
+            name: ubuntu-server-tegra-jetson-arm64
+            display-name: Ubuntu Server Tegra Jetson arm64
+            revision: 2
+            architecture: arm64
+            series: jammy
+            class: preinstalled
+            kernel: linux-nvidia-tegra-jetson
+            gadget:
+              url: "https://git.launchpad.net/~canonical-foundations/snap-pc/+git/github-mirror-amd64"
+              branch: classic
+              type: "git"
+            rootfs:
+              mirror: "http://ports.ubuntu.com/ubuntu-ports/"
+              pocket: updates
+              components:
+                - main
+                - restricted
+                # TODO should ideally not enable universe during image build; kernel is now
+                # in main, but need to MIR nvidia-tegra-defaults and list it in a seed (see
+                # LP #2083775 for a proposal to add seeds)
+                - universe
+                - multiverse
+              seed:
+                urls:
+                  - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+                branch: jammy
+                names:
+                  - server
+                  - minimal
+                  - standard
+                  - cloud-image
+                  # TODO would like to list server-tegra here once available (see
+                  # LP #2083775)
+            customization:
+              # We need to duplicate the list of components as we currently have some
+              # packages in universe and multiverse
+              components:
+                - main
+                - restricted
+                - universe
+                - multiverse
+              cloud-init:
+                user-data: |
+                  #cloud-config
+                  chpasswd:
+                    expire: true
+                    users:
+                      - name: ubuntu
+                        password: ubuntu
+                        type: text
+                meta-data: |
+                  dsmode: local
+                  instance_id: ubuntu-server
+              extra-snaps:
+                - name: snapd
+                # FIXME ubuntu-image fails in prepare_image if this isn't listed: cannot
+                # add snap "lxd" without also adding its base "core20" explicitly
+                - name: core20
+              extra-packages:
+                # FIXME using extra-packages as a workaround for missing bits to make the
+                # system bootable and has the right platform specific packages installed;
+                # this could be pulled by seeds or metapackages while we design a more
+                # scalable solution (see LP #2083775)
+                # signed EFI boot chain
+                - name: grub-efi-arm64-signed
+                - name: shim-signed
+                # add serial consoles to cmdline via GRUB config
+                - name: nvidia-tegra-defaults
+                # to get wireless support with netplan.io
+                - name: wpasupplicant
+                # install Tegra Orin firmware files
+                - name: linux-firmware-nvidia-tegra
+            artifacts:
+              img:
+                -
+                  name: ubuntu-22.04-preinstalled-server-arm64+tegra-jetson.img
+              manifest:
+                name: ubuntu-22.04-preinstalled-server-arm64+tegra-jetson.manifest
+
+   .. group-tab:: Noble
+
+      .. code-block:: bash
+
+            name: ubuntu-server-jetson-arm64
+            display-name: Ubuntu Server Jetson arm64
+            revision: 1
+            architecture: arm64
+            series: noble
+            class: preinstalled
+            kernel: linux-nvidia-tegra-jetson
+            gadget:
+              url: "https://git.launchpad.net/~canonical-foundations/snap-pc/+git/github-mirror-amd64"
+              branch: "classic"
+              type: "git"
+            rootfs:
+              archive: ubuntu
+              components:
+                - main
+                - restricted
+                - universe
+                - multiverse
+              mirror: "http://ports.ubuntu.com/ubuntu-ports/"
+              sources-list-deb822: true
+              pocket: updates
+              seed:
+                urls:
+                  - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+                branch: noble
+                names:
+                  - server
+                  - minimal
+                  - standard
+                  - cloud-image
+            customization:
+              extra-snaps:
+                - name: snapd
+              extra-packages:
+                # FIXME using extra-packages as a workaround for missing bits to make the
+                # system bootable that should be pulled by seeds or metapackages
+                # signed EFI boot chain
+                - name: grub-efi-arm64-signed
+                - name: shim-signed
+                # for update-grub
+                - name: grub2-common
+                - name: nvidia-tegra-defaults
+                - name: wpasupplicant
+                # install Tegra firmware files
+                - name: linux-firmware-nvidia-tegra
+              cloud-init:
+                user-data: |
+                  #cloud-config
+                  chpasswd:
+                    expire: true
+                    users:
+                      - name: ubuntu
+                        password: ubuntu
+                        type: text
+                meta-data: |
+                  dsmode: local
+                  instance_id: ubuntu-server
+            artifacts:
+              img:
+                - name: ubuntu-24.04-preinstalled-server-arm64+jetson.img
+              manifest:
+                name: ubuntu-24.04-preinstalled-server-arm64+jetson.manifest
 
 Build the Classic Server image
 ------------------------------

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -20,7 +20,7 @@ Create an image definition file
 
 An image definition file, in YAML format, defines the various configurations required to build a custom Ubuntu image:
 
-* **class**: Defines the type of image, such as `cloud`, `installer` or `preinstalled` (Canonical's certified Server images are preinstalled).
+* **class**: Defines the type of image, such as `cloud`, `installer` or `preinstalled` (Canonical certified Server images are preinstalled).
 * **kernel**: Specifies the preinstalled kernel in the image. The official Ubuntu kernel for Jetson is "linux-nvidia-tegra-jetson", but it can be replaced with an alternative custom kernel, for instance hosted in a PPA for development purpose.
 * **gadget**: Boot assets of an image.
 * **customization**: Features such as particular snaps and packages that will come installed in the image.
@@ -30,14 +30,12 @@ For more details about each field, refer to the `image definition`_ documentatio
 
 .. _image definition: https://github.com/canonical/ubuntu-image/blob/main/internal/imagedefinition/README.rst
 
-The `ubuntu-images`_ repository serves as the official source for Canonical’s image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
-
-.. _ubuntu-images: https://git.launchpad.net/ubuntu-images
-
 Ubuntu certified Image definition files
 ---------------------------------------
 
-The following command allows to check the definition files used to generate the Ubuntu Server image certified by Canonical:
+The ubuntu-images repository serves as the official source for Canonical image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
+
+The following commands allow to check the definition files used to generate the Ubuntu Server image certified by Canonical:
 
 .. tabs::
 

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -64,4 +64,4 @@ Once the corresponding image definition file is created, the server image can be
 
     sudo ubuntu-image classic <image_definition>.yaml --debug
 
-On the example above, the `--debug`  flag prints additional information about each step executed as part of the image build process, useful to troubleshoot any issues while running the command.
+In the example above, the `--debug` flag prints additional information about each step executed as part of the image build process, coming in handy to troubleshoot any issues.

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -1,4 +1,4 @@
-.. _build-image:
+.. _build-server-image:
 
 Create a custom Ubuntu Server image
 ===================================

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -1,7 +1,7 @@
 .. _build-server-image:
 
-Create a custom Ubuntu Server image
-===================================
+Create a custom Ubuntu Server preinstalled image
+================================================
 
 
 Prerequisites

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -18,7 +18,7 @@ Prerequisites
 Create an image definition file
 -------------------------------
 
-An image definition YAML file is required to build a custom Ubuntu Server image. This file specifies the required configurations, such as the ones listed below.
+An image definition file, in YAML format, defines the various configurations required to build a custom Ubuntu image:
 
 * **class**: Defines the type of image, such as `cloud`, `installer` or `preinstalled` (Canonical's certified Server images are preinstalled).
 * **kernel**: Specifies the preinstalled kernel in the image. The official Ubuntu kernel for Jetson is "linux-nvidia-tegra-jetson", but it can be replaced with an alternative custom kernel, for instance hosted in a PPA for development purpose.

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -33,7 +33,7 @@ For more details about each field, refer to the `image definition`_ documentatio
 Ubuntu certified Image definition files
 ---------------------------------------
 
-The ubuntu-images repository serves as the official source for Canonical image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
+The ubuntu-images repository serves as the official source for Canonical image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) on Jetson Orin platforms and 24.04 (Noble Numbat) for Jetson Thor devices.
 
 The following commands allow to check the definition files used to generate the Ubuntu Server image certified by Canonical:
 

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -58,7 +58,7 @@ The following commands allow to check the definition files used to generate the 
 Build the Classic Server image
 ------------------------------
 
-Once the corresponding image definition file is defined, the server image can be built through the following command.
+Once the corresponding image definition file is created, the server image can be built through the following command.
 
 .. code-block:: bash
 

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -39,18 +39,23 @@ Ubuntu certified Image definition files
 
 The following command allows to check the definition files used to generate the Ubuntu Server image certified by Canonical:
 
-.. _Certified Ubuntu Server Jammy image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=jammy
-.. _Certified Ubuntu Server Noble image definition: https://git.launchpad.net/ubuntu-images/tree/ubuntu-server-tegra-jetson.yaml?h=noble
-
 .. tabs::
 
    .. group-tab:: Jammy
 
-      `Certified Ubuntu Server Jammy image definition`_
+      .. code-block:: bash
+
+         git clone -b jammy https://git.launchpad.net/ubuntu-images
+         cd ubuntu-images
+         cat ubuntu-server-tegra-jetson.yaml
 
    .. group-tab:: Noble
 
-      `Certified Ubuntu Server Noble image definition`_
+      .. code-block:: bash
+
+         git clone -b noble https://git.launchpad.net/ubuntu-images
+         cd ubuntu-images
+         cat ubuntu-server-tegra-jetson.yaml
 
 Build the Classic Server image
 ------------------------------

--- a/docs/how-to/build-server-image.rst
+++ b/docs/how-to/build-server-image.rst
@@ -33,7 +33,7 @@ For more details about each field, refer to the `image definition`_ documentatio
 Ubuntu certified Image definition files
 ---------------------------------------
 
-The ubuntu-images repository serves as the official source for Canonical image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) on Jetson Orin platforms and 24.04 (Noble Numbat) for Jetson Thor devices.
+The ubuntu-images repository serves as the official source for Canonical image definitions and scripts. It is used to build various Ubuntu versions and flavors. This includes optimized versions for Jetson Tegra hardware, currently supporting Ubuntu 22.04 (Jammy Jellyfish) for Jetson Orin platforms and 24.04 (Noble Numbat) for Jetson Thor devices.
 
 The following commands allow to check the definition files used to generate the Ubuntu Server image certified by Canonical:
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -6,3 +6,4 @@ How-to guides
 
    flash
    secure-boot
+   build-image

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -6,4 +6,4 @@ How-to guides
 
    flash
    secure-boot
-   build-image
+   build-server-image


### PR DESCRIPTION
## Description

We’ve been asked multiples times about how could an ODM build a customized Ubuntu image, this PR proposes few commands and examples explaining how to do that.

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1202

## Tests

The following tests were executed.

* Build a Jammy image on a Jammy host and test that it boots in a Jammy DUT.
* Build a Jammy image on a Noble host and test that it boots in a Jammy DUT.
* Build a Noble image on a Jammy host and test that it boots in a Noble DUT.
* Build a Noble image on a Noble host and test that it boots in a Noble DUT.
 
[tests-11-03-2026.zip](https://github.com/user-attachments/files/25921293/tests-11-03-2026.zip)

