### PR TITLE
fix: Use the correct baseurl for sphinx-sitemap.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,7 +184,7 @@ html_theme_options = {
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/en/latest/'
+html_baseurl = 'https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/'
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:


### PR DESCRIPTION
If we append `/en/latest`, the URLs in the generated sitemap will be of the form `/en/latest/latest` which will not be found.

Therefore, remove that suffix from the baseurl.